### PR TITLE
Use tar on all platforms

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -20,7 +20,7 @@ import {
   cacheDir,
   find
 } from '@actions/tool-cache';
-import {getOctokit} from '@actions/github';
+import { getOctokit } from '@actions/github';
 
 import * as fs from 'fs';
 
@@ -30,8 +30,8 @@ async function setup() {
   let version = core.getInput('version');
   if (version.length === 0) {
     // If no version is specified, the latest version is used by default.
-    const token = core.getInput('token', {required: true});
-    const octokit = getOctokit(token, {baseUrl: 'https://api.github.com'});
+    const token = core.getInput('token', { required: true });
+    const octokit = getOctokit(token, { baseUrl: 'https://api.github.com' });
     const release = await octokit.rest.repos.getLatestRelease({
       owner: 'mozilla',
       repo: 'sccache'
@@ -160,12 +160,7 @@ function getPlatform(): Error | string {
 }
 
 function getExtension(): string {
-  switch (process.platform) {
-    case 'win32':
-      return 'zip';
-    default:
-      return 'tar.gz';
-  }
+  return 'tar.gz'
 }
 
 setup().catch(err => {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -20,7 +20,7 @@ import {
   cacheDir,
   find
 } from '@actions/tool-cache';
-import { getOctokit } from '@actions/github';
+import {getOctokit} from '@actions/github';
 
 import * as fs from 'fs';
 
@@ -30,8 +30,8 @@ async function setup() {
   let version = core.getInput('version');
   if (version.length === 0) {
     // If no version is specified, the latest version is used by default.
-    const token = core.getInput('token', { required: true });
-    const octokit = getOctokit(token, { baseUrl: 'https://api.github.com' });
+    const token = core.getInput('token', {required: true});
+    const octokit = getOctokit(token, {baseUrl: 'https://api.github.com'});
     const release = await octokit.rest.repos.getLatestRelease({
       owner: 'mozilla',
       repo: 'sccache'
@@ -160,7 +160,7 @@ function getPlatform(): Error | string {
 }
 
 function getExtension(): string {
-  return 'tar.gz'
+  return 'tar.gz';
 }
 
 setup().catch(err => {


### PR DESCRIPTION
Windows was initially setup to use the .zip files produced on the releases [here](https://github.com/mozilla/sccache/releases) however when we want to use this action on a Windows ARM machine, there is no zip file produced for the release. However there is [sccache-v0.10.0-aarch64-pc-windows-msvc.tar.gz](https://github.com/mozilla/sccache/releases/download/v0.10.0/sccache-v0.10.0-aarch64-pc-windows-msvc.tar.gz) which would be usable in Windows on ARM.

Upon further inspection it seems that _only_ the `x86_64` Windows variant also seems to produce a zip and is the only variation to also include a .zip version. 

It seems like we can simplify this code by just always using `.tar.gz` versions since it seems like they are always produced and optionally the .zip gets produced. I'm doing a bit of guess work here since it's unclear why the x86_64 version of Windows also produces the zip version of the release.