### PR TITLE
Add job id to annotation title

### DIFF
--- a/src/show_stats.ts
+++ b/src/show_stats.ts
@@ -133,7 +133,10 @@ function format_json_stats(stats: Stats): {
     stats.stats.compiler_write_duration
   );
 
-  const notice = `${ratio}% - ${cache_hit_count} hits, ${cache_miss_count} misses, ${cache_error_count} errors`;
+  const notice_hit = plural(cache_hit_count, 'hit');
+  const notice_miss = plural(cache_miss_count, 'miss', 'misses');
+  const notice_error = plural(cache_error_count, 'error');
+  const notice = `${ratio}% - ${notice_hit}, ${notice_miss}, ${notice_error}`;
 
   const table = [
     [{data: 'Cache hit %', header: true}, {data: `${ratio}%`}],
@@ -168,4 +171,8 @@ function format_json_stats(stats: Stats): {
 
 function percentage(x: number, y: number): number {
   return Math.round((x / y) * 100 || 0);
+}
+
+function plural(count: number, base: string, plural = base + 's'): string {
+  return `${count} ${count === 1 ? base : plural}`;
 }


### PR DESCRIPTION
This fixes #124 as well as I believe is reasonably possible. There are some workarounds that can get job names in some cases, but in my opinion they are not robust enough to be worth the complexity. See [actions/toolkit#74](https://redirect.github.com/actions/toolkit/issues/74) for details.

This also tweaks the annotation text to use singular/plural forms correctly.

<details>
<summary>Example</summary>

See <https://github.com/wetheredge/VerTX/actions/runs/16064600558>. `clippy-vertx` and `build` get repeated for each job in the matrix.

<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/user-attachments/assets/da346f8a-ef5a-4402-9ab9-1982dc403152">
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/user-attachments/assets/ebaf359d-6da6-43f9-b6e9-5c224b0b3e7a">
  <img alt="screenshot of annotations box showing the updates" src="https://github.com/user-attachments/assets/da346f8a-ef5a-4402-9ab9-1982dc403152">
</picture>
</details>
