### PR TITLE
ci: verify committed dist/ matches a clean rebuild

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,6 +37,30 @@ jobs:
       - name: Build & Test
         run: npm run test
 
+  verify-dist:
+    name: Verify dist/ is up to date
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: npm
+
+      - name: npm ci
+        run: npm ci
+      - name: Rebuild dist/
+        run: npm run build
+      - name: Check dist/ matches committed output
+        run: |
+          if ! git diff --exit-code -- dist/; then
+            echo "::error::Committed dist/ does not match a clean rebuild from source."
+            echo "::error::Run 'npm ci && npm run build' locally and commit the updated dist/ before releasing."
+            exit 1
+          fi
+
   test:
     name: Test version
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Context

Apache Infrastructure runs an automated verifier (`verify-action-build`) on every Dependabot bump of a GitHub Action used across ASF projects. For each bump, it checks out the new tag in an isolated container, rebuilds `dist/` from source, and compares against the published `dist/`. A mismatch blocks auto-approval of the bump.

On the `v0.0.9 → v0.0.10` bump of this action, the verifier flagged a drift. On investigation:

- A clean `npm ci && npm run build` on Node 24 against the `v0.0.10` source tree produces a `dist/setup/index.js` of ~650 KB.
- The committed `dist/setup/index.js` at `v0.0.10` is ~642 KB and differs byte-for-byte.
- When the verifier retries the rebuild after restoring `package.json` + `package-lock.json` from the `v0.0.9` commit, the output matches the published `dist/` exactly.

In other words, the `prepare version 0.0.10` commit bumped the version strings in the lockfile but the `dist/` shipped alongside it was built against the earlier toolchain. The release is functionally fine, but downstream rebuild-based verifiers can't reconcile it with the manifests, and they block the bump.

This is not unique to v0.0.10 — the same thing could happen on any release if the release workflow isn't enforcing a fresh rebuild at tag time.

## What this PR does

This is **one of several possible remediations** for what our verifier detected. A narrower fix would be to rebuild `dist/` now and push a patch release; that addresses the immediate symptom but doesn't prevent it from recurring.

This PR takes the preventive path instead: it adds a `verify-dist` job to `CI.yml` that runs on every push and PR, does `npm ci && npm run build` on Node 24 (matching `action.yml`'s `using: node24`), and fails if the committed `dist/` differs from the rebuilt output. Future releases that ship a stale `dist/` will then be caught here rather than by downstream consumers.

Note that, as expected, this CI job will **initially fail on `main`** until `dist/` is regenerated and committed — which is also the signal that the check is doing its job. Happy to open a follow-up rebuild PR if you'd prefer, or you can rebuild locally and push to `main` when you're ready.

## Why Node 24 specifically

`action.yml` declares `using: node24`, so consumers bundle against Node 24 at runtime. The existing `build` / `test` / `test_disable_annotations` jobs in `CI.yml` still use Node 18.x; I left those alone and pinned only the new `verify-dist` job to 24.x, so the rebuild it performs matches what the action actually runs on.

## Test plan

- [ ] New `verify-dist` job runs in this PR's CI.
- [ ] Job fails with a `::error::` annotation on `main` (confirms the check detects the current drift).
- [ ] After a clean rebuild + commit of `dist/`, the job passes.

Generated-by: Claude Opus 4.7 (1M context)